### PR TITLE
Add Preview Action and Fix Save Action

### DIFF
--- a/rplugin/python3/denite/kind/session.py
+++ b/rplugin/python3/denite/kind/session.py
@@ -59,6 +59,5 @@ class Kind(Openable):
         """ Overwrite the first selected session """
         target = context['targets'][0]
         file_path = target['action__path']
-        self.vim.call('delete', file_path)
-        self.vim.command("mksession! '{}'".format(file_path))
+        self.vim.command("mksession! {}".format(file_path))
         self.vim.command("let v:this_session = '{}'".format(file_path))

--- a/rplugin/python3/denite/kind/session.py
+++ b/rplugin/python3/denite/kind/session.py
@@ -31,7 +31,7 @@ class Kind(Openable):
         self.vim.command('silent! source {}'.format(path))
 
     def action_preview(self, context):
-        """ Opens a session that will not autosave """
+        """ Opens a session anonymously """
         eval_current = int(self.vim.eval('exists("v:this_session")'))
         if eval_current:
             current = self.vim.eval('v:this_session')

--- a/rplugin/python3/denite/kind/session.py
+++ b/rplugin/python3/denite/kind/session.py
@@ -32,9 +32,9 @@ class Kind(Openable):
 
     def action_preview(self, context):
         """ Opens a session that will not autosave """
-        eval_session = int(vim.eval('exists("v:this_session")'))
+        eval_session = int(self.vim.eval('exists("v:this_session")'))
         if eval_session:
-            this_session = vim.eval("v:this_session")
+            this_session = self.vim.eval("v:this_session")
         else:
             this_session = "''"
         self.action_open(context)

--- a/rplugin/python3/denite/kind/session.py
+++ b/rplugin/python3/denite/kind/session.py
@@ -32,7 +32,7 @@ class Kind(Openable):
 
     def action_preview(self, context):
         """ Previews first selected session after wiping out all buffers """
-        self.action_open(self, context)
+        self.action_open(context)
         self.vim.command("let v:this_session = ''")
 
     def action_delete(self, context):

--- a/rplugin/python3/denite/kind/session.py
+++ b/rplugin/python3/denite/kind/session.py
@@ -32,13 +32,13 @@ class Kind(Openable):
 
     def action_preview(self, context):
         """ Opens a session that will not autosave """
-        eval_session = int(self.vim.eval('exists("v:this_session")'))
-        if eval_session:
-            this_session = self.vim.eval("v:this_session")
+        eval_current = int(self.vim.eval('exists("v:this_session")'))
+        if eval_current:
+            current = self.vim.eval('v:this_session')
         else:
-            this_session = "''"
+            current = ""
         self.action_open(context)
-        self.vim.command("let v:this_session = {}".format(this_session))
+        self.vim.command("let v:this_session = '{}'".format(current))
 
     def action_delete(self, context):
         """ Delete selected session(s) """

--- a/rplugin/python3/denite/kind/session.py
+++ b/rplugin/python3/denite/kind/session.py
@@ -30,6 +30,11 @@ class Kind(Openable):
         self.vim.command('noautocmd silent! %bwipeout!')
         self.vim.command('silent! source {}'.format(path))
 
+    def action_preview(self, context):
+        """ Previews first selected session after wiping out all buffers """
+        self.action_open(self, context)
+        self.vim.command("let v:this_session = ''")
+
     def action_delete(self, context):
         """ Delete selected session(s) """
         for target in context['targets']:

--- a/rplugin/python3/denite/kind/session.py
+++ b/rplugin/python3/denite/kind/session.py
@@ -32,8 +32,8 @@ class Kind(Openable):
 
     def action_preview(self, context):
         """ Opens a session anonymously """
-        eval_current = int(self.vim.eval('exists("v:this_session")'))
-        if eval_current:
+        current_exists = int(self.vim.eval('exists("v:this_session")'))
+        if current_exists:
             current = self.vim.eval('v:this_session')
         else:
             current = ""

--- a/rplugin/python3/denite/kind/session.py
+++ b/rplugin/python3/denite/kind/session.py
@@ -32,8 +32,13 @@ class Kind(Openable):
 
     def action_preview(self, context):
         """ Opens a session that will not autosave """
+        eval_session = int(vim.eval('exists("v:this_session")'))
+        if eval_session:
+            this_session = vim.eval("v:this_session")
+        else:
+            this_session = "''"
         self.action_open(context)
-        self.vim.command("let v:this_session = ''")
+        self.vim.command("let v:this_session = {}".format(this_session))
 
     def action_delete(self, context):
         """ Delete selected session(s) """

--- a/rplugin/python3/denite/kind/session.py
+++ b/rplugin/python3/denite/kind/session.py
@@ -59,5 +59,6 @@ class Kind(Openable):
         """ Overwrite the first selected session """
         target = context['targets'][0]
         file_path = target['action__path']
+        self.vim.call('delete', file_path)
         self.vim.command("mksession! '{}'".format(file_path))
         self.vim.command("let v:this_session = '{}'".format(file_path))

--- a/rplugin/python3/denite/kind/session.py
+++ b/rplugin/python3/denite/kind/session.py
@@ -31,7 +31,7 @@ class Kind(Openable):
         self.vim.command('silent! source {}'.format(path))
 
     def action_preview(self, context):
-        """ Previews first selected session after wiping out all buffers """
+        """ Opens a session that will not autosave """
         self.action_open(context)
         self.vim.command("let v:this_session = ''")
 


### PR DESCRIPTION
1. Add a preview action to allow a new session to be loaded anonymously.
If a session is previewed after a session has been previously opened the previously opened session will be set. 
 
2. Fixed the save action